### PR TITLE
Edit to manifest.json to allow the extension to access https urls.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
 	,"permissions": [
 		"tabs"
 		,"http://*/"
+		,"https://*/"
 		,"background"
 	]
 }


### PR DESCRIPTION
Fixes "Origin chrome-extension://xxx is not allowed by Access-Control-Allow-Origin" error when accessing Jenkins/Hudson instance secured with ssl.
