### PR TITLE
Use friendly "display name" for radiator and popup

### DIFF
--- a/lib/js/radiator.js
+++ b/lib/js/radiator.js
@@ -75,6 +75,7 @@
                     name.id = "div_"+decodeURIComponent(job.name).replace(/ /g,"");
                     if (job.details && job.details.lastBuild){
                         lastBuild = job.details.lastBuild;
+                        name.display = job.details.displayName;
                         colour = job.details.color || job.color;
                         if (lastBuild.details){
                             culprits = lastBuild.details.culprits;

--- a/popup.html
+++ b/popup.html
@@ -26,7 +26,7 @@
 </div>
 <script id="jenkins-list-item" type="text/mustache">
     {{#jobs}}
-    <li class="{{canClassName color}}"><a href="{{url}}">{{name}}</a></li>
+    <li class="{{canClassName color}}"><a href="{{url}}">{{details.displayName}}</a></li>
     {{/jobs}}
 </script>
 </body>


### PR DESCRIPTION
Fix for clanceyp/monitor-me-jenkins#4 

If the display name is not defined then it contains the
project name anyway.
